### PR TITLE
Fix watch position to actually track continuously. 

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 
 export function useStickyState(defaultValue, key) {
   const [value, setValue] = useState(() => {
@@ -31,4 +31,10 @@ export function useDelayUnmount(isMounted, delayTime) {
   }, [isMounted, delayTime, shouldRender])
   
   return shouldRender
+}
+
+export function usePrevious(value) {
+  const ref = useRef()
+  useEffect(() => { ref.current = value }, [value])
+  return ref.current
 }


### PR DESCRIPTION
Previously not having watchId be listed as depended on by the useEffect meant that the watch was being cleaned up on every re-render.

Also fix a bug that was causing the recenter button to pop up immediately when lots of geolocation watch data would come in immediately before the userLocation was set away from null.